### PR TITLE
feat(badge): adjust padding and add inner styling for Badge component

### DIFF
--- a/packages/react/src/badge/Badge.module.css
+++ b/packages/react/src/badge/Badge.module.css
@@ -12,3 +12,9 @@
   --cocso-badge-border-radius: inherit;
   --cocso-badge-bg-color: inherit;
 }
+
+.inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}

--- a/packages/react/src/badge/Badge.tsx
+++ b/packages/react/src/badge/Badge.tsx
@@ -35,7 +35,7 @@ export const Badge = forwardRef<HTMLDivElement, BadgeProps>(
           lineHeight="tight"
           asChild
         >
-          <span>{children}</span>
+          <span className={styles.inner}>{children}</span>
         </Typography>
       </div>
     );
@@ -45,8 +45,8 @@ export const Badge = forwardRef<HTMLDivElement, BadgeProps>(
 const getPadding = (size: BadgeSize) =>
   match(size)
     .with('sm', () => '4px 8px')
-    .with('md', () => '6px 12px')
-    .with('lg', () => '8px 16px')
+    .with('md', () => '6px 10px')
+    .with('lg', () => '8px 12px')
     .exhaustive();
 
 const getFontSize = (size: BadgeSize) =>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an inner wrapper for badge content and tightens medium/large padding.
> 
> - **Badge component (`packages/react/src/badge/Badge.tsx`)**:
>   - Wraps children in `span` with `styles.inner` for inline-flex alignment.
>   - Adjusts `getPadding`:
>     - `md`: `6px 12px` → `6px 10px`
>     - `lg`: `8px 16px` → `8px 12px`
> - **Styles (`packages/react/src/badge/Badge.module.css`)**:
>   - Adds `.inner` class with `inline-flex`, centered alignment, and `gap: 2px`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9c5ce235159b34eecbda4f16262f892e9f2fb23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * Badge 컴포넌트의 내부 레이아웃 개선으로 더 나은 정렬과 간격 조정
  * 중간 및 큰 크기의 Badge에서 패딩값 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->