### PR TITLE
fix(website): close remaining PR #109 review threads

### DIFF
--- a/apps/website/src/app/api/md/[...slug]/route.ts
+++ b/apps/website/src/app/api/md/[...slug]/route.ts
@@ -25,6 +25,11 @@ const PROPS_ENTRY_RE = /\{[^{}]*\}/g;
 const PIPE_RE = /\|/g;
 const SECTION_SPLIT_RE = /^## /gm;
 
+const OVERVIEW_SECTION_TITLES = new Set(["overview"]);
+const API_REFERENCE_SECTION_TITLES = new Set(["api reference"]);
+const ACCESSIBILITY_SECTION_TITLES = new Set(["accessibility", "접근성"]);
+const IMPORT_SECTION_TITLES = new Set(["import", "가져오기"]);
+
 interface Props {
   params: Promise<{ slug: string[] }>;
 }
@@ -42,7 +47,10 @@ export async function GET(_request: Request, { params }: Props) {
 
   let body: string;
   try {
-    const rawMdx = await readFile(join(CONTENT_DIR, `${slug.join("/")}.mdx`), "utf-8");
+    const rawMdx = await readFile(
+      join(CONTENT_DIR, `${slug.join("/")}.mdx`),
+      "utf-8"
+    );
     const converted = await mdxToMarkdown(rawMdx);
     body = converted.includes("## API Reference")
       ? restructureComponentDoc(converted)
@@ -164,10 +172,29 @@ function splitIntoSections(md: string): MdSection[] {
 function restructureComponentDoc(md: string): string {
   const sections = splitIntoSections(md);
 
-  const overview = sections.find((s) => s.title === "Overview");
-  const apiRef = sections.find((s) => s.title === "API Reference");
-  const exampleSections = sections.filter(
-    (s) => s.title !== "Overview" && s.title !== "API Reference"
+  const isOverviewSection = (title: string) =>
+    OVERVIEW_SECTION_TITLES.has(normalizeSectionTitle(title));
+  const isApiReferenceSection = (title: string) =>
+    API_REFERENCE_SECTION_TITLES.has(normalizeSectionTitle(title));
+  const isAccessibilitySection = (title: string) =>
+    ACCESSIBILITY_SECTION_TITLES.has(normalizeSectionTitle(title));
+  const isImportSection = (title: string) =>
+    IMPORT_SECTION_TITLES.has(normalizeSectionTitle(title));
+
+  const overview = sections.find((s) => isOverviewSection(s.title));
+  const apiRef = sections.find((s) => isApiReferenceSection(s.title));
+
+  const contentSections = sections.filter(
+    (s) => !(isOverviewSection(s.title) || isApiReferenceSection(s.title))
+  );
+  const accessibility = contentSections.find((s) =>
+    isAccessibilitySection(s.title)
+  );
+  const usage =
+    contentSections.find((s) => isImportSection(s.title)) ??
+    contentSections.find((s) => !isAccessibilitySection(s.title));
+  const examples = contentSections.filter(
+    (s) => s !== accessibility && s !== usage
   );
 
   const parts: string[] = [];
@@ -175,6 +202,10 @@ function restructureComponentDoc(md: string): string {
   // Overview text as intro paragraph
   if (overview?.content) {
     parts.push(overview.content, "");
+  }
+
+  if (accessibility?.content) {
+    parts.push("## Accessibility", "", accessibility.content, "");
   }
 
   // Installation
@@ -187,14 +218,14 @@ function restructureComponentDoc(md: string): string {
   );
 
   // Usage — first example section
-  if (exampleSections.length > 0) {
-    parts.push("", "## Usage", "", exampleSections[0].content);
+  if (usage?.content) {
+    parts.push("", "## Usage", "", usage.content);
   }
 
   // Examples — remaining sections demoted to ###
-  if (exampleSections.length > 1) {
+  if (examples.length > 0) {
     parts.push("", "## Examples");
-    for (const section of exampleSections.slice(1)) {
+    for (const section of examples) {
       parts.push("", `### ${section.title}`, "", section.content);
     }
   }
@@ -205,6 +236,10 @@ function restructureComponentDoc(md: string): string {
   }
 
   return parts.join("\n");
+}
+
+function normalizeSectionTitle(title: string): string {
+  return title.trim().toLowerCase();
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/website/src/app/llms.txt/route.ts
+++ b/apps/website/src/app/llms.txt/route.ts
@@ -1,17 +1,31 @@
 import { source } from "~/libs/source";
 
+const LEADING_SLASHES_RE = /^\/+/;
+const TRAILING_SLASHES_RE = /\/+$/;
+
 export function GET() {
   const pages = source.getPages("en");
 
-  const gettingStarted = pages.filter((p) => p.slugs[0] === "getting-started");
-  const foundations = pages.filter((p) => p.slugs[0] === "foundations");
-  const components = pages.filter((p) => p.slugs[0] === "components");
+  const toCanonicalPath = (url: string) =>
+    url.replace(LEADING_SLASHES_RE, "").replace(TRAILING_SLASHES_RE, "");
+  const topLevelSection = (url: string) =>
+    toCanonicalPath(url).split("/")[0] ?? "";
+
+  const gettingStarted = pages.filter(
+    (page) => topLevelSection(page.url) === "getting-started"
+  );
+  const foundations = pages.filter(
+    (page) => topLevelSection(page.url) === "foundations"
+  );
+  const components = pages.filter(
+    (page) => topLevelSection(page.url) === "components"
+  );
 
   const formatLinks = (items: typeof pages) =>
     items
       .map(
-        (p) =>
-          `- [${p.data.title}](https://cocso-ui.com/${p.slugs.join("/")}.md): ${p.data.description ?? ""}`
+        (page) =>
+          `- [${page.data.title}](https://cocso-ui.com/${toCanonicalPath(page.url)}.md): ${page.data.description ?? ""}`
       )
       .join("\n");
 

--- a/apps/website/src/components/layout/header.tsx
+++ b/apps/website/src/components/layout/header.tsx
@@ -15,6 +15,10 @@ import { MobileSidebar } from "./mobile-sidebar";
 export const Header = () => {
   const { setOpenSearch } = useSearchContext();
   const locale = useLocale();
+  const labels =
+    locale === "en"
+      ? { home: "cocso-ui home", search: "Search" }
+      : { home: "cocso-ui 홈", search: "검색" };
   const homeHref =
     locale === "en"
       ? "/getting-started/introduction"
@@ -25,7 +29,7 @@ export const Header = () => {
       <div className="row-between h-full w-full">
         <div className="center-y h-full">
           <Link
-            aria-label="cocso-ui 홈"
+            aria-label={labels.home}
             className="center-y ml-(--size-app-padding) gap-1"
             href={homeHref}
           >
@@ -39,7 +43,7 @@ export const Header = () => {
           <LanguageSwitcher />
           <div aria-hidden="true" className="h-full w-px bg-neutral-200" />
           <Button
-            aria-label="검색"
+            aria-label={labels.search}
             className="h-full rounded-none"
             onClick={() => setOpenSearch(true)}
             svgOnly


### PR DESCRIPTION
## Summary
- fix markdown export restructuring so `## Usage` is derived from the real import/usage section instead of incorrectly promoting Accessibility
- generate `llms.txt` links/grouping from canonical `page.url` paths to avoid locale-slug mismatch and broken `.md` links
- localize header aria-labels for the search icon button (and home link label) based on active locale

## Validation
- `pnpm check` ✅ passed
- `pnpm build` ❌ failed at `@cocso-ui/website` with `Module not found: Can't resolve 'flexsearch'` from `fumadocs-core` import chain (pre-existing dependency/runtime issue not introduced by this patch)