### PR TITLE
fix(website): decode HTML entities in markdown code output

### DIFF
--- a/apps/website/src/app/api/md/[...slug]/route.ts
+++ b/apps/website/src/app/api/md/[...slug]/route.ts
@@ -24,6 +24,8 @@ const EXCESSIVE_NEWLINES_RE = /\n{3,}/g;
 const PROPS_ENTRY_RE = /\{[^{}]*\}/g;
 const PIPE_RE = /\|/g;
 const SECTION_SPLIT_RE = /^## /gm;
+const MARKDOWN_CODE_FENCE_RE = /```([^\n`]*)\n([\s\S]*?)\n```/g;
+const MARKDOWN_INLINE_CODE_RE = /`([^`\n]+)`/g;
 
 const OVERVIEW_SECTION_TITLES = new Set(["overview"]);
 const API_REFERENCE_SECTION_TITLES = new Set(["api reference"]);
@@ -135,8 +137,7 @@ async function mdxToMarkdown(raw: string): Promise<string> {
     examples.has(name) ? `\`\`\`tsx\n${examples.get(name)}\n\`\`\`` : ""
   );
 
-  // Decode HTML entities (safe after all JSX tags are stripped)
-  md = decodeHtmlEntities(md);
+  md = decodeMarkdownCodeEntities(md);
 
   // Clean up excessive blank lines
   md = md.replace(EXCESSIVE_NEWLINES_RE, "\n\n");
@@ -290,7 +291,28 @@ const HTML_ENTITY_MAP: Record<string, string> = {
 const HTML_ENTITY_RE = /&(?:lt|gt|amp|quot|#39);/g;
 
 function decodeHtmlEntities(text: string): string {
-  return text.replace(HTML_ENTITY_RE, (entity) => HTML_ENTITY_MAP[entity] ?? entity);
+  return text.replace(
+    HTML_ENTITY_RE,
+    (entity) => HTML_ENTITY_MAP[entity] ?? entity
+  );
+}
+
+function decodeMarkdownCodeEntities(markdown: string): string {
+  const decodedFences = markdown.replace(
+    MARKDOWN_CODE_FENCE_RE,
+    (_fullMatch, infoString: string, code: string) => {
+      const decodedCode = decodeHtmlEntities(code);
+      return `\`\`\`${infoString}\n${decodedCode}\n\`\`\``;
+    }
+  );
+
+  return decodedFences.replace(
+    MARKDOWN_INLINE_CODE_RE,
+    (_fullMatch, code: string) => {
+      const decodedCode = decodeHtmlEntities(code);
+      return `\`${decodedCode}\``;
+    }
+  );
 }
 
 function extractField(objStr: string, field: string): string | undefined {


### PR DESCRIPTION
## Summary
- Fix `.md` endpoint conversion so HTML entities are decoded only inside markdown code spans/fenced blocks.
- Prevent prose from being globally decoded, avoiding reintroduction of raw HTML-like tags in normal text.
- Keep existing MDX-to-markdown restructuring flow intact while resolving escaped-code readability.

## Validation
- `pnpm --filter @cocso-ui/website lint`
- `pnpm --filter @cocso-ui/website build`
- `lsp_diagnostics` on `apps/website/src/app/api/md/[...slug]/route.ts` (no diagnostics)