### PR TITLE
docs(website): add component pages for Alert, Avatar, Breadcrumb, Card, Progress, Skeleton

### DIFF
--- a/apps/website/content/en/components/alert.mdx
+++ b/apps/website/content/en/components/alert.mdx
@@ -1,0 +1,63 @@
+---
+title: Alert
+description: A contextual feedback message that communicates status or important information.
+---
+
+<Section>
+  <Section.Title>Overview</Section.Title>
+  <Section.Text>Alert renders a contextual feedback banner with four semantic variants. It supports an optional icon slot and a dismiss button for transient notifications.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>Use <code>info</code> for neutral informational messages.</Section.ListItem>
+    <Section.ListItem>Use <code>success</code> to confirm a completed action.</Section.ListItem>
+    <Section.ListItem>Use <code>warning</code> to communicate a potential problem or caution.</Section.ListItem>
+    <Section.ListItem>Use <code>error</code> to signal a failure or destructive condition.</Section.ListItem>
+    <Section.ListItem>Provide <code>onClose</code> to add a dismiss button for transient alerts.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Accessibility</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>Alert renders with <code>role="alert"</code>, which causes screen readers to announce the content immediately when it appears.</Section.ListItem>
+    <Section.ListItem>The close button has a built-in <code>aria-label="Close"</code>. Override it when additional context helps screen reader users (e.g., <code>"Dismiss warning"</code>).</Section.ListItem>
+    <Section.ListItem>For persistent alerts that should not interrupt the reading flow, consider <code>role="status"</code> via the HTML <code>role</code> prop instead.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Alert } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>Default</Section.Title>
+  <Section.Text>All four semantic variants in their default appearance.</Section.Text>
+  <ComponentExample name="alert-default" />
+</Section>
+
+<Section>
+  <Section.Title>With Close Button</Section.Title>
+  <Section.Text>Pass an <code>onClose</code> callback to render a dismiss button inside the alert.</Section.Text>
+  <ComponentExample name="alert-variants" />
+</Section>
+
+<Section>
+  <Section.Title>API Reference</Section.Title>
+
+  <SubHeading>Alert</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "variant", type: '"info" | "success" | "warning" | "error"', default: '"info"', description: "Controls the background color and icon color to communicate semantic meaning." },
+      { name: "icon", type: "ReactNode", description: "Optional icon element rendered before the content. Use an icon from `@cocso-ui/react-icons` that matches the variant." },
+      { name: "onClose", type: "() => void", description: "When provided, renders a close button. Call this to remove or hide the alert from the UI." },
+      { name: "children", type: "ReactNode", required: true, description: "The alert message content." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/en/components/avatar.mdx
+++ b/apps/website/content/en/components/avatar.mdx
@@ -1,0 +1,67 @@
+---
+title: Avatar
+description: A visual identifier for a user or entity, with image, initials fallback, or icon.
+---
+
+<Section>
+  <Section.Title>Overview</Section.Title>
+  <Section.Text>Avatar displays a user or entity image. When no image is available it falls back to initials derived from the <code>fallback</code> prop or the first character of <code>alt</code>. If neither is provided, it renders a neutral placeholder.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>Always provide <code>alt</code> for accessibility even when using a fallback.</Section.ListItem>
+    <Section.ListItem>Use <code>fallback</code> to override the auto-generated initial (e.g., for two-letter initials like <code>"JD"</code>).</Section.ListItem>
+    <Section.ListItem>Use <code>shape="square"</code> for brand logos or non-person entities.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Accessibility</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>Provide a meaningful <code>alt</code> text so screen readers can identify the avatar's subject.</Section.ListItem>
+    <Section.ListItem>When the avatar is decorative and accompanied by visible text, pass <code>alt=""</code> to suppress the announcement.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Avatar } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>Default</Section.Title>
+  <Section.Text>Avatar with an image source, an initials fallback, and a placeholder fallback.</Section.Text>
+  <ComponentExample name="avatar-default" />
+</Section>
+
+<Section>
+  <Section.Title>Size</Section.Title>
+  <Section.Text>Five sizes are available: <code>xs</code>, <code>sm</code>, <code>md</code>, <code>lg</code>, and <code>xl</code>. The default is <code>md</code>.</Section.Text>
+  <ComponentExample name="avatar-sizes" />
+</Section>
+
+<Section>
+  <Section.Title>Shape</Section.Title>
+  <Section.Text>Two shape options are available. Use <code>circle</code> for people and <code>square</code> for brands or entities.</Section.Text>
+  <ComponentExample name="avatar-shapes" />
+</Section>
+
+<Section>
+  <Section.Title>API Reference</Section.Title>
+
+  <SubHeading>Avatar</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "src", type: "string", description: "URL of the avatar image. When omitted, the component renders a fallback." },
+      { name: "alt", type: "string", description: "Alternative text for the image and source for auto-generating a single-letter initial." },
+      { name: "fallback", type: "string", description: "Text rendered when no image is available. Overrides the auto-generated initial from `alt`." },
+      { name: "size", type: '"xs" | "sm" | "md" | "lg" | "xl"', default: '"md"', description: "Controls the dimensions of the avatar." },
+      { name: "shape", type: '"circle" | "square"', default: '"circle"', description: "Controls the border-radius. Use `square` for logos or non-person entities." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/en/components/breadcrumb.mdx
+++ b/apps/website/content/en/components/breadcrumb.mdx
@@ -1,0 +1,60 @@
+---
+title: Breadcrumb
+description: A navigation hierarchy indicator that shows the user's current location within the site.
+---
+
+<Section>
+  <Section.Title>Overview</Section.Title>
+  <Section.Text>Breadcrumb renders an ordered list of navigation links separated by a configurable separator. It marks the current page as the last item and wraps the list in a <code>&lt;nav&gt;</code> element for accessibility.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>Pass anchor elements (<code>&lt;a&gt;</code>) for navigable ancestors and a <code>&lt;span&gt;</code> for the current page.</Section.ListItem>
+    <Section.ListItem>The last child is automatically styled as the active page and receives no separator after it.</Section.ListItem>
+    <Section.ListItem>Override the separator via the <code>separator</code> prop — use a string (e.g., <code>"/"</code>) or any ReactNode.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Accessibility</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>The wrapping <code>&lt;nav&gt;</code> element has <code>aria-label="Breadcrumb"</code> so screen readers identify the landmark.</Section.ListItem>
+    <Section.ListItem>Separators are hidden from assistive technologies via <code>aria-hidden="true"</code>.</Section.ListItem>
+    <Section.ListItem>Mark the current page with <code>aria-current="page"</code> on the last item for screen reader users.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Breadcrumb } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>Default</Section.Title>
+  <Section.Text>Basic breadcrumb with the default chevron separator.</Section.Text>
+  <ComponentExample name="breadcrumb-default" />
+</Section>
+
+<Section>
+  <Section.Title>Size</Section.Title>
+  <Section.Text>Three sizes are available: <code>sm</code>, <code>md</code>, and <code>lg</code>. The default is <code>md</code>.</Section.Text>
+  <ComponentExample name="breadcrumb-sizes" />
+</Section>
+
+<Section>
+  <Section.Title>API Reference</Section.Title>
+
+  <SubHeading>Breadcrumb</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "size", type: '"sm" | "md" | "lg"', default: '"md"', description: "Controls the font size of the breadcrumb items." },
+      { name: "separator", type: "ReactNode", default: "<ChevronRightIcon />", description: "The separator element rendered between each breadcrumb item. Pass a string or any React element." },
+      { name: "children", type: "ReactNode", required: true, description: "The breadcrumb items. Pass anchor elements for navigable ancestors and a span for the current page." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/en/components/card.mdx
+++ b/apps/website/content/en/components/card.mdx
@@ -1,0 +1,60 @@
+---
+title: Card
+description: A contained surface for grouping related content with configurable elevation and padding.
+---
+
+<Section>
+  <Section.Title>Overview</Section.Title>
+  <Section.Text>Card is a flexible container that groups related content within a visually distinct surface. Three variants cover common elevation patterns — use <code>elevated</code> for floating content, <code>outlined</code> for bordered sections, and <code>filled</code> for subtle background grouping.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>Use <code>elevated</code> for primary content cards that need visual prominence.</Section.ListItem>
+    <Section.ListItem>Use <code>outlined</code> when a clear boundary is needed without adding depth.</Section.ListItem>
+    <Section.ListItem>Use <code>filled</code> for secondary areas or nested content regions.</Section.ListItem>
+    <Section.ListItem>Adjust <code>padding</code> to match the density requirements of the content inside.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Accessibility</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>Card renders as a <code>&lt;div&gt;</code> with no implicit role. Add semantic structure to its content (headings, lists) to aid navigation.</Section.ListItem>
+    <Section.ListItem>If a card acts as a clickable region, use a <code>&lt;button&gt;</code> or <code>&lt;a&gt;</code> inside rather than attaching click handlers to the card itself.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Card } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>Default</Section.Title>
+  <Section.Text>A card with default elevated style and medium padding.</Section.Text>
+  <ComponentExample name="card-default" />
+</Section>
+
+<Section>
+  <Section.Title>Variant</Section.Title>
+  <Section.Text>Three visual variants adjust the elevation and border style.</Section.Text>
+  <ComponentExample name="card-variants" />
+</Section>
+
+<Section>
+  <Section.Title>API Reference</Section.Title>
+
+  <SubHeading>Card</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "variant", type: '"elevated" | "outlined" | "filled"', default: '"elevated"', description: "Controls the visual style of the card. `elevated` adds a shadow, `outlined` adds a border, `filled` uses a background color." },
+      { name: "padding", type: '"sm" | "md" | "lg"', default: '"md"', description: "Controls the internal padding. Adjust based on content density." },
+      { name: "children", type: "ReactNode", required: true, description: "The content rendered inside the card." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/en/components/progress.mdx
+++ b/apps/website/content/en/components/progress.mdx
@@ -1,0 +1,66 @@
+---
+title: Progress
+description: A determinate progress bar that visualizes completion as a percentage.
+---
+
+<Section>
+  <Section.Title>Overview</Section.Title>
+  <Section.Text>Progress renders a horizontal bar that fills proportionally to the current <code>value</code> relative to <code>max</code>. It uses semantic color variants to communicate the nature of the operation and three sizes to match surrounding content density.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>Always provide a <code>value</code> for determinate progress. For indeterminate loading, use Spinner instead.</Section.ListItem>
+    <Section.ListItem>Use semantic variants (<code>success</code>, <code>danger</code>) to reflect the outcome of the tracked operation.</Section.ListItem>
+    <Section.ListItem>Set <code>max</code> when the total is not 100 (e.g., steps in a multi-step form).</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Accessibility</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>Renders with <code>role="progressbar"</code> and the correct <code>aria-valuenow</code>, <code>aria-valuemin</code>, and <code>aria-valuemax</code> attributes.</Section.ListItem>
+    <Section.ListItem>Add an <code>aria-label</code> or <code>aria-labelledby</code> to associate the bar with a visible label for screen readers.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Progress } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>Default</Section.Title>
+  <Section.Text>Progress bars at 25%, 50%, 75%, and 100% completion.</Section.Text>
+  <ComponentExample name="progress-default" />
+</Section>
+
+<Section>
+  <Section.Title>Variant</Section.Title>
+  <Section.Text>Six semantic color variants indicate the nature of the tracked operation.</Section.Text>
+  <ComponentExample name="progress-variants" />
+</Section>
+
+<Section>
+  <Section.Title>Size</Section.Title>
+  <Section.Text>Three sizes control the height of the track: <code>sm</code>, <code>md</code>, and <code>lg</code>. The default is <code>md</code>.</Section.Text>
+  <ComponentExample name="progress-sizes" />
+</Section>
+
+<Section>
+  <Section.Title>API Reference</Section.Title>
+
+  <SubHeading>Progress</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "value", type: "number", required: true, description: "Current progress value. Clamped to the range [0, max]." },
+      { name: "max", type: "number", default: "100", description: "Maximum value. Set this when tracking steps or items rather than a percentage." },
+      { name: "variant", type: '"primary" | "secondary" | "success" | "danger" | "warning" | "info"', default: '"primary"', description: "Controls the fill color to communicate the semantic meaning of the progress." },
+      { name: "size", type: '"sm" | "md" | "lg"', default: '"md"', description: "Controls the height of the progress track." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/en/components/skeleton.mdx
+++ b/apps/website/content/en/components/skeleton.mdx
@@ -1,0 +1,65 @@
+---
+title: Skeleton
+description: A loading placeholder that previews the shape of content before it loads.
+---
+
+<Section>
+  <Section.Title>Overview</Section.Title>
+  <Section.Text>Skeleton renders a neutral placeholder element that mimics the shape of the content it replaces. Use it during data fetching to reduce perceived layout shift and communicate that content is on its way.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>Match the <code>variant</code> to the shape of the content: <code>text</code> for lines, <code>circular</code> for avatars or icons, <code>rectangular</code> for images or cards.</Section.ListItem>
+    <Section.ListItem>Use <code>style</code> to set explicit width and height when the skeleton needs to match a specific content region.</Section.ListItem>
+    <Section.ListItem>Prefer <code>pulse</code> for most cases. Use <code>wave</code> for a more prominent shimmer effect. Use <code>none</code> when motion is distracting (e.g., inside a dense table).</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Accessibility</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>Skeleton renders with <code>aria-hidden="true"</code> so screen readers skip the placeholder entirely.</Section.ListItem>
+    <Section.ListItem>Pair skeletons with a live region (e.g., <code>aria-live="polite"</code>) that announces when content has finished loading.</Section.ListItem>
+    <Section.ListItem>The pulse and wave animations respect the <code>prefers-reduced-motion</code> media query.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Skeleton } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>Default</Section.Title>
+  <Section.Text>A composite skeleton mimicking a typical list item with an avatar and text lines.</Section.Text>
+  <ComponentExample name="skeleton-default" />
+</Section>
+
+<Section>
+  <Section.Title>Variant</Section.Title>
+  <Section.Text>Three shape variants match the geometry of common UI elements.</Section.Text>
+  <ComponentExample name="skeleton-variants" />
+</Section>
+
+<Section>
+  <Section.Title>Animation</Section.Title>
+  <Section.Text>Three animation modes: <code>pulse</code> fades in and out, <code>wave</code> sweeps a shimmer effect, <code>none</code> is static.</Section.Text>
+  <ComponentExample name="skeleton-animations" />
+</Section>
+
+<Section>
+  <Section.Title>API Reference</Section.Title>
+
+  <SubHeading>Skeleton</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "variant", type: '"text" | "circular" | "rectangular"', default: '"text"', description: "Controls the shape of the skeleton. Match this to the shape of the content being loaded." },
+      { name: "animation", type: '"pulse" | "wave" | "none"', default: '"pulse"', description: "Controls the animation style. Use `none` when the skeleton appears in a dense or motion-sensitive context." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/en/getting-started/mcp-connection.mdx
+++ b/apps/website/content/en/getting-started/mcp-connection.mdx
@@ -6,7 +6,7 @@ description: Connect AI clients to the hosted COCSO MCP endpoint and reuse @cocs
 <Section>
   <Section.Title>Overview</Section.Title>
   <Section.Text>The documentation site exposes a hosted MCP endpoint so AI clients can discover and reuse existing `@cocso-ui` components before generating custom UI.</Section.Text>
-  <Section.Text>Endpoint URL: <Link href="https://www.cocso-ui.com/api/mcp" target="_blank" rel="noopener noreferrer" type="custom" size="current">https://www.cocso-ui.com/api/mcp<LinkExternalIcon /></Link></Section.Text>
+  <Section.Text>Endpoint URL: <Link href="https://www.cocso-ui.com/api/mcp" target="_blank" rel="noopener noreferrer" type="custom" size="current">{"https://www.cocso-ui.com/api/mcp"}<LinkExternalIcon /></Link></Section.Text>
 </Section>
 
 <Section>

--- a/apps/website/content/ko/components/alert.mdx
+++ b/apps/website/content/ko/components/alert.mdx
@@ -1,0 +1,63 @@
+---
+title: Alert
+description: 상태나 중요한 정보를 전달하는 맥락형 피드백 메시지입니다.
+---
+
+<Section>
+  <Section.Title>개요</Section.Title>
+  <Section.Text>Alert는 네 가지 시맨틱 변형을 가진 맥락형 피드백 배너를 렌더링합니다. 선택적 아이콘 슬롯과 일시적 알림을 위한 닫기 버튼을 지원합니다.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>중립적인 정보 메시지에는 <code>info</code>를 사용합니다.</Section.ListItem>
+    <Section.ListItem>완료된 작업을 확인할 때는 <code>success</code>를 사용합니다.</Section.ListItem>
+    <Section.ListItem>잠재적 문제나 주의사항을 전달할 때는 <code>warning</code>을 사용합니다.</Section.ListItem>
+    <Section.ListItem>실패나 파괴적인 상태를 알릴 때는 <code>error</code>를 사용합니다.</Section.ListItem>
+    <Section.ListItem>일시적인 알림에 닫기 버튼을 추가하려면 <code>onClose</code>를 제공하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>접근성</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>Alert는 <code>role="alert"</code>로 렌더링되어 스크린 리더가 콘텐츠를 즉시 읽습니다.</Section.ListItem>
+    <Section.ListItem>닫기 버튼에는 기본적으로 <code>aria-label="Close"</code>가 적용됩니다. 추가 맥락이 필요할 때는 재정의하세요.</Section.ListItem>
+    <Section.ListItem>읽기 흐름을 방해하지 않아야 하는 지속적인 알림에는 HTML <code>role</code> prop을 통해 <code>role="status"</code>를 사용하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Alert } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>기본</Section.Title>
+  <Section.Text>네 가지 시맨틱 변형의 기본 모습입니다.</Section.Text>
+  <ComponentExample name="alert-default" />
+</Section>
+
+<Section>
+  <Section.Title>닫기 버튼</Section.Title>
+  <Section.Text><code>onClose</code> 콜백을 전달하면 Alert 내부에 닫기 버튼이 렌더링됩니다.</Section.Text>
+  <ComponentExample name="alert-variants" />
+</Section>
+
+<Section>
+  <Section.Title>API 레퍼런스</Section.Title>
+
+  <SubHeading>Alert</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "variant", type: '"info" | "success" | "warning" | "error"', default: '"info"', description: "시맨틱 의미를 전달하기 위해 배경색과 아이콘 색상을 제어합니다." },
+      { name: "icon", type: "ReactNode", description: "콘텐츠 앞에 렌더링되는 선택적 아이콘 요소입니다. 변형에 맞는 `@cocso-ui/react-icons`의 아이콘을 사용하세요." },
+      { name: "onClose", type: "() => void", description: "제공 시 닫기 버튼을 렌더링합니다. 이 함수를 호출하여 Alert를 제거하거나 숨기세요." },
+      { name: "children", type: "ReactNode", required: true, description: "Alert 메시지 콘텐츠입니다." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/ko/components/avatar.mdx
+++ b/apps/website/content/ko/components/avatar.mdx
@@ -1,0 +1,67 @@
+---
+title: Avatar
+description: 이미지, 이니셜 폴백, 또는 아이콘을 사용하는 사용자 또는 엔티티의 시각적 식별자입니다.
+---
+
+<Section>
+  <Section.Title>개요</Section.Title>
+  <Section.Text>Avatar는 사용자 또는 엔티티 이미지를 표시합니다. 이미지가 없으면 <code>fallback</code> prop 또는 <code>alt</code>의 첫 번째 문자로부터 파생된 이니셜로 대체됩니다. 둘 다 없으면 중립적인 플레이스홀더를 렌더링합니다.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>폴백을 사용하더라도 접근성을 위해 항상 <code>alt</code>를 제공하세요.</Section.ListItem>
+    <Section.ListItem>두 글자 이니셜(예: <code>"JD"</code>)과 같이 자동 생성된 이니셜을 재정의하려면 <code>fallback</code>을 사용하세요.</Section.ListItem>
+    <Section.ListItem>브랜드 로고나 사람이 아닌 엔티티에는 <code>shape="square"</code>를 사용하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>접근성</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>스크린 리더가 아바타의 주체를 식별할 수 있도록 의미 있는 <code>alt</code> 텍스트를 제공하세요.</Section.ListItem>
+    <Section.ListItem>아바타가 장식적이고 주변에 텍스트가 있는 경우 <code>alt=""</code>를 전달하여 읽기를 억제하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Avatar } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>기본</Section.Title>
+  <Section.Text>이미지 소스, 이니셜 폴백, 플레이스홀더 폴백이 있는 아바타입니다.</Section.Text>
+  <ComponentExample name="avatar-default" />
+</Section>
+
+<Section>
+  <Section.Title>크기</Section.Title>
+  <Section.Text>다섯 가지 크기를 사용할 수 있습니다: <code>xs</code>, <code>sm</code>, <code>md</code>, <code>lg</code>, <code>xl</code>. 기본값은 <code>md</code>입니다.</Section.Text>
+  <ComponentExample name="avatar-sizes" />
+</Section>
+
+<Section>
+  <Section.Title>모양</Section.Title>
+  <Section.Text>두 가지 모양 옵션을 사용할 수 있습니다. 사람에게는 <code>circle</code>을, 브랜드나 엔티티에는 <code>square</code>를 사용하세요.</Section.Text>
+  <ComponentExample name="avatar-shapes" />
+</Section>
+
+<Section>
+  <Section.Title>API 레퍼런스</Section.Title>
+
+  <SubHeading>Avatar</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "src", type: "string", description: "아바타 이미지의 URL입니다. 생략 시 폴백을 렌더링합니다." },
+      { name: "alt", type: "string", description: "이미지의 대체 텍스트이자 한 글자 이니셜 자동 생성의 소스입니다." },
+      { name: "fallback", type: "string", description: "이미지가 없을 때 렌더링되는 텍스트입니다. `alt`로부터 자동 생성된 이니셜을 재정의합니다." },
+      { name: "size", type: '"xs" | "sm" | "md" | "lg" | "xl"', default: '"md"', description: "아바타의 크기를 제어합니다." },
+      { name: "shape", type: '"circle" | "square"', default: '"circle"', description: "border-radius를 제어합니다. 로고나 사람이 아닌 엔티티에는 `square`를 사용하세요." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/ko/components/breadcrumb.mdx
+++ b/apps/website/content/ko/components/breadcrumb.mdx
@@ -1,0 +1,60 @@
+---
+title: Breadcrumb
+description: 사이트 내 사용자의 현재 위치를 보여주는 탐색 계층 표시기입니다.
+---
+
+<Section>
+  <Section.Title>개요</Section.Title>
+  <Section.Text>Breadcrumb는 설정 가능한 구분자로 구분된 탐색 링크의 정렬된 목록을 렌더링합니다. 현재 페이지를 마지막 항목으로 표시하고 목록을 접근성을 위한 <code>&lt;nav&gt;</code> 요소로 감쌉니다.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>탐색 가능한 상위 항목에는 앵커 요소(<code>&lt;a&gt;</code>)를, 현재 페이지에는 <code>&lt;span&gt;</code>을 전달하세요.</Section.ListItem>
+    <Section.ListItem>마지막 자식은 자동으로 활성 페이지로 스타일링되며 뒤에 구분자가 렌더링되지 않습니다.</Section.ListItem>
+    <Section.ListItem><code>separator</code> prop으로 구분자를 재정의할 수 있습니다 — 문자열(예: <code>"/"</code>) 또는 ReactNode를 사용하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>접근성</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>감싸는 <code>&lt;nav&gt;</code> 요소에 <code>aria-label="Breadcrumb"</code>가 있어 스크린 리더가 랜드마크를 식별합니다.</Section.ListItem>
+    <Section.ListItem>구분자는 <code>aria-hidden="true"</code>로 보조 기술에서 숨겨집니다.</Section.ListItem>
+    <Section.ListItem>스크린 리더 사용자를 위해 마지막 항목에 <code>aria-current="page"</code>를 표시하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Breadcrumb } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>기본</Section.Title>
+  <Section.Text>기본 chevron 구분자를 사용하는 기본 브레드크럼입니다.</Section.Text>
+  <ComponentExample name="breadcrumb-default" />
+</Section>
+
+<Section>
+  <Section.Title>크기</Section.Title>
+  <Section.Text>세 가지 크기를 사용할 수 있습니다: <code>sm</code>, <code>md</code>, <code>lg</code>. 기본값은 <code>md</code>입니다.</Section.Text>
+  <ComponentExample name="breadcrumb-sizes" />
+</Section>
+
+<Section>
+  <Section.Title>API 레퍼런스</Section.Title>
+
+  <SubHeading>Breadcrumb</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "size", type: '"sm" | "md" | "lg"', default: '"md"', description: "브레드크럼 항목의 폰트 크기를 제어합니다." },
+      { name: "separator", type: "ReactNode", default: "<ChevronRightIcon />", description: "각 브레드크럼 항목 사이에 렌더링되는 구분자 요소입니다. 문자열 또는 React 요소를 전달하세요." },
+      { name: "children", type: "ReactNode", required: true, description: "브레드크럼 항목들입니다. 탐색 가능한 상위 항목에는 앵커 요소를, 현재 페이지에는 span을 전달하세요." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/ko/components/card.mdx
+++ b/apps/website/content/ko/components/card.mdx
@@ -1,0 +1,60 @@
+---
+title: Card
+description: 설정 가능한 elevation과 패딩으로 관련 콘텐츠를 그룹화하는 컨테이너 표면입니다.
+---
+
+<Section>
+  <Section.Title>개요</Section.Title>
+  <Section.Text>Card는 시각적으로 구분되는 표면 내에 관련 콘텐츠를 그룹화하는 유연한 컨테이너입니다. 세 가지 변형이 일반적인 elevation 패턴을 커버합니다 — 부유하는 콘텐츠에는 <code>elevated</code>, 테두리가 있는 섹션에는 <code>outlined</code>, 미묘한 배경 그룹화에는 <code>filled</code>를 사용하세요.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>시각적 강조가 필요한 주요 콘텐츠 카드에는 <code>elevated</code>를 사용합니다.</Section.ListItem>
+    <Section.ListItem>깊이감 없이 명확한 경계가 필요할 때는 <code>outlined</code>를 사용합니다.</Section.ListItem>
+    <Section.ListItem>보조 영역이나 중첩된 콘텐츠 영역에는 <code>filled</code>를 사용합니다.</Section.ListItem>
+    <Section.ListItem>내부 콘텐츠의 밀도 요구사항에 맞게 <code>padding</code>을 조정하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>접근성</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>Card는 암시적 역할 없이 <code>&lt;div&gt;</code>로 렌더링됩니다. 탐색을 돕기 위해 콘텐츠에 시맨틱 구조(제목, 목록)를 추가하세요.</Section.ListItem>
+    <Section.ListItem>카드가 클릭 가능한 영역으로 작동하는 경우, 카드 자체에 클릭 핸들러를 붙이는 대신 내부에 <code>&lt;button&gt;</code> 또는 <code>&lt;a&gt;</code>를 사용하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Card } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>기본</Section.Title>
+  <Section.Text>기본 elevated 스타일과 medium 패딩이 적용된 카드입니다.</Section.Text>
+  <ComponentExample name="card-default" />
+</Section>
+
+<Section>
+  <Section.Title>Variant</Section.Title>
+  <Section.Text>세 가지 시각적 변형이 elevation과 테두리 스타일을 조정합니다.</Section.Text>
+  <ComponentExample name="card-variants" />
+</Section>
+
+<Section>
+  <Section.Title>API 레퍼런스</Section.Title>
+
+  <SubHeading>Card</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "variant", type: '"elevated" | "outlined" | "filled"', default: '"elevated"', description: "카드의 시각적 스타일을 제어합니다. `elevated`는 그림자를 추가하고, `outlined`는 테두리를 추가하며, `filled`는 배경색을 사용합니다." },
+      { name: "padding", type: '"sm" | "md" | "lg"', default: '"md"', description: "내부 패딩을 제어합니다. 콘텐츠 밀도에 따라 조정하세요." },
+      { name: "children", type: "ReactNode", required: true, description: "카드 내부에 렌더링되는 콘텐츠입니다." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/ko/components/progress.mdx
+++ b/apps/website/content/ko/components/progress.mdx
@@ -1,0 +1,66 @@
+---
+title: Progress
+description: 완료율을 시각화하는 확정적 진행 표시줄입니다.
+---
+
+<Section>
+  <Section.Title>개요</Section.Title>
+  <Section.Text>Progress는 <code>max</code>에 대한 현재 <code>value</code>의 비율로 채워지는 수평 막대를 렌더링합니다. 시맨틱 색상 변형을 사용해 작업의 성격을 전달하고, 세 가지 크기로 주변 콘텐츠 밀도에 맞출 수 있습니다.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>확정적 진행에는 항상 <code>value</code>를 제공하세요. 불확정적 로딩에는 Spinner를 사용하세요.</Section.ListItem>
+    <Section.ListItem>추적 중인 작업의 결과를 반영하려면 시맨틱 변형(<code>success</code>, <code>danger</code>)을 사용하세요.</Section.ListItem>
+    <Section.ListItem>총량이 100이 아닐 때(예: 다단계 폼의 단계)는 <code>max</code>를 설정하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>접근성</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem><code>role="progressbar"</code>와 올바른 <code>aria-valuenow</code>, <code>aria-valuemin</code>, <code>aria-valuemax</code> 속성으로 렌더링됩니다.</Section.ListItem>
+    <Section.ListItem>스크린 리더를 위해 표시 레이블과 연결하려면 <code>aria-label</code> 또는 <code>aria-labelledby</code>를 추가하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Progress } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>기본</Section.Title>
+  <Section.Text>25%, 50%, 75%, 100% 완료율의 진행 표시줄입니다.</Section.Text>
+  <ComponentExample name="progress-default" />
+</Section>
+
+<Section>
+  <Section.Title>Variant</Section.Title>
+  <Section.Text>여섯 가지 시맨틱 색상 변형이 추적 중인 작업의 성격을 나타냅니다.</Section.Text>
+  <ComponentExample name="progress-variants" />
+</Section>
+
+<Section>
+  <Section.Title>크기</Section.Title>
+  <Section.Text>세 가지 크기가 트랙의 높이를 제어합니다: <code>sm</code>, <code>md</code>, <code>lg</code>. 기본값은 <code>md</code>입니다.</Section.Text>
+  <ComponentExample name="progress-sizes" />
+</Section>
+
+<Section>
+  <Section.Title>API 레퍼런스</Section.Title>
+
+  <SubHeading>Progress</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "value", type: "number", required: true, description: "현재 진행 값입니다. [0, max] 범위로 클램프됩니다." },
+      { name: "max", type: "number", default: "100", description: "최대 값입니다. 퍼센트가 아닌 단계나 항목을 추적할 때 설정하세요." },
+      { name: "variant", type: '"primary" | "secondary" | "success" | "danger" | "warning" | "info"', default: '"primary"', description: "진행의 시맨틱 의미를 전달하기 위해 채우기 색상을 제어합니다." },
+      { name: "size", type: '"sm" | "md" | "lg"', default: '"md"', description: "진행 트랙의 높이를 제어합니다." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/ko/components/skeleton.mdx
+++ b/apps/website/content/ko/components/skeleton.mdx
@@ -1,0 +1,65 @@
+---
+title: Skeleton
+description: 콘텐츠가 로드되기 전에 모양을 미리 보여주는 로딩 플레이스홀더입니다.
+---
+
+<Section>
+  <Section.Title>개요</Section.Title>
+  <Section.Text>Skeleton은 대체하는 콘텐츠의 모양을 모방하는 중립적인 플레이스홀더 요소를 렌더링합니다. 데이터 로딩 중에 지각적 레이아웃 이동을 줄이고 콘텐츠가 곧 나타날 것임을 전달하는 데 사용하세요.</Section.Text>
+  <Section.UnorderedList>
+    <Section.ListItem>콘텐츠의 모양에 맞게 <code>variant</code>를 선택하세요: 텍스트 줄에는 <code>text</code>, 아바타나 아이콘에는 <code>circular</code>, 이미지나 카드에는 <code>rectangular</code>.</Section.ListItem>
+    <Section.ListItem>특정 콘텐츠 영역에 맞춰야 할 때는 <code>style</code>로 명시적인 너비와 높이를 설정하세요.</Section.ListItem>
+    <Section.ListItem>대부분의 경우 <code>pulse</code>를 선호하세요. 더 두드러진 시머 효과에는 <code>wave</code>를 사용하세요. 밀집한 테이블 내부처럼 움직임이 방해될 때는 <code>none</code>을 사용하세요.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>접근성</Section.Title>
+  <Section.UnorderedList>
+    <Section.ListItem>Skeleton은 <code>aria-hidden="true"</code>로 렌더링되어 스크린 리더가 플레이스홀더를 건너뜁니다.</Section.ListItem>
+    <Section.ListItem>콘텐츠 로딩이 완료되면 알려주는 라이브 영역(예: <code>aria-live="polite"</code>)과 함께 사용하세요.</Section.ListItem>
+    <Section.ListItem>pulse와 wave 애니메이션은 <code>prefers-reduced-motion</code> 미디어 쿼리를 존중합니다.</Section.ListItem>
+  </Section.UnorderedList>
+</Section>
+
+<Section>
+  <Section.Title>Import</Section.Title>
+  ```tsx
+  import { Skeleton } from "@cocso-ui/react";
+  ```
+</Section>
+
+<Section>
+  <Section.Title>기본</Section.Title>
+  <Section.Text>아바타와 텍스트 줄이 있는 일반적인 목록 항목을 모방하는 복합 스켈레톤입니다.</Section.Text>
+  <ComponentExample name="skeleton-default" />
+</Section>
+
+<Section>
+  <Section.Title>Variant</Section.Title>
+  <Section.Text>세 가지 모양 변형이 일반적인 UI 요소의 형태와 일치합니다.</Section.Text>
+  <ComponentExample name="skeleton-variants" />
+</Section>
+
+<Section>
+  <Section.Title>애니메이션</Section.Title>
+  <Section.Text>세 가지 애니메이션 모드: <code>pulse</code>는 페이드 인/아웃, <code>wave</code>는 시머 효과를 쓸어내립니다, <code>none</code>은 정적입니다.</Section.Text>
+  <ComponentExample name="skeleton-animations" />
+</Section>
+
+<Section>
+  <Section.Title>API 레퍼런스</Section.Title>
+
+  <SubHeading>Skeleton</SubHeading>
+
+  <PropsTable
+    data={[
+      { name: "variant", type: '"text" | "circular" | "rectangular"', default: '"text"', description: "스켈레톤의 모양을 제어합니다. 로드 중인 콘텐츠의 모양과 일치시키세요." },
+      { name: "animation", type: '"pulse" | "wave" | "none"', default: '"pulse"', description: "애니메이션 스타일을 제어합니다. 밀집하거나 움직임에 민감한 컨텍스트에서는 `none`을 사용하세요." },
+    ]}
+  />
+</Section>
+
+<Section>
+  <PageNavigation />
+</Section>

--- a/apps/website/content/ko/getting-started/mcp-connection.mdx
+++ b/apps/website/content/ko/getting-started/mcp-connection.mdx
@@ -6,7 +6,7 @@ description: AI 클라이언트를 COCSO MCP 엔드포인트에 연결해 @cocso
 <Section>
   <Section.Title>개요</Section.Title>
   <Section.Text>문서 사이트는 hosted MCP 엔드포인트를 제공하며, AI 클라이언트가 커스텀 UI를 새로 만들기 전에 기존 `@cocso-ui` 컴포넌트를 먼저 탐색하도록 돕습니다.</Section.Text>
-  <Section.Text>엔드포인트 URL: <Link href="https://www.cocso-ui.com/api/mcp" target="_blank" rel="noopener noreferrer" type="custom" size="current">https://www.cocso-ui.com/api/mcp<LinkExternalIcon /></Link></Section.Text>
+  <Section.Text>엔드포인트 URL: <Link href="https://www.cocso-ui.com/api/mcp" target="_blank" rel="noopener noreferrer" type="custom" size="current">{"https://www.cocso-ui.com/api/mcp"}<LinkExternalIcon /></Link></Section.Text>
 </Section>
 
 <Section>

--- a/apps/website/src/app/api/md/[...slug]/route.ts
+++ b/apps/website/src/app/api/md/[...slug]/route.ts
@@ -14,6 +14,7 @@ const SECTION_TEXT_RE = /<Section\.Text>\s*([\s\S]*?)\s*<\/Section\.Text>/g;
 const SECTION_LIST_ITEM_RE =
   /<Section\.ListItem>([\s\S]*?)<\/Section\.ListItem>/g;
 const PROPS_TABLE_RE = /<PropsTable\s+data=\{(\[[\s\S]*?\])\}\s*\/>/g;
+const JSX_STRING_EXPR_RE = /\{"([^"\\]*)"\}/g;
 const SECTION_WRAPPER_RE = /<\/?Section(?:\.[A-Za-z]+)?>/g;
 const COMPONENT_EXAMPLE_OPEN_RE = /<ComponentExample[^>]*>/g;
 const COMPONENT_EXAMPLE_CLOSE_RE = /<\/ComponentExample>/g;
@@ -129,6 +130,7 @@ async function mdxToMarkdown(raw: string): Promise<string> {
   md = md.replace(PAGE_NAV_RE, "");
 
   md = md.replace(/<\/?[A-Z][A-Za-z.]*(?:\s[^>]*)?\/?>/g, "");
+  md = md.replace(JSX_STRING_EXPR_RE, "$1");
   md = md.replace(JSX_INDENT_RE, "");
 
   md = md.replace(

--- a/apps/website/src/app/api/md/[...slug]/route.ts
+++ b/apps/website/src/app/api/md/[...slug]/route.ts
@@ -161,8 +161,8 @@ function splitIntoSections(md: string): MdSection[] {
       sections.push({ title: parts[i].trim(), content: "" });
     } else {
       sections.push({
-        title: parts[i].substring(0, newlineIdx).trim(),
-        content: parts[i].substring(newlineIdx + 1).trim(),
+        title: parts[i].slice(0, newlineIdx).trim(),
+        content: parts[i].slice(newlineIdx + 1).trim(),
       });
     }
   }

--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -1,5 +1,6 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css");
 @import "tailwindcss";
+@import "@cocso-ui/css/tailwind4.css";
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 

--- a/apps/website/src/components/example/alert-default.tsx
+++ b/apps/website/src/components/example/alert-default.tsx
@@ -1,0 +1,14 @@
+import { Alert } from "@cocso-ui/react";
+
+export default function AlertDefault() {
+  return (
+    <div className="flex flex-col gap-3 p-4" style={{ width: 480 }}>
+      <Alert variant="info">Your session will expire in 10 minutes.</Alert>
+      <Alert variant="success">Changes saved successfully.</Alert>
+      <Alert variant="warning">Your account storage is almost full.</Alert>
+      <Alert variant="error">
+        Failed to submit the form. Please try again.
+      </Alert>
+    </div>
+  );
+}

--- a/apps/website/src/components/example/alert-variants.tsx
+++ b/apps/website/src/components/example/alert-variants.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Alert } from "@cocso-ui/react";
+import { useState } from "react";
+
+export default function AlertVariants() {
+  const [dismissed, setDismissed] = useState<string[]>([]);
+
+  const variants = ["info", "success", "warning", "error"] as const;
+
+  return (
+    <div className="flex flex-col gap-3 p-4" style={{ width: 480 }}>
+      {variants
+        .filter((v) => !dismissed.includes(v))
+        .map((variant) => (
+          <Alert
+            key={variant}
+            onClose={() => setDismissed((prev) => [...prev, variant])}
+            variant={variant}
+          >
+            This is a <strong>{variant}</strong> alert message.
+          </Alert>
+        ))}
+      {dismissed.length > 0 && (
+        <button
+          className="text-neutral-500 text-sm underline"
+          onClick={() => setDismissed([])}
+          type="button"
+        >
+          Reset
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/website/src/components/example/avatar-default.tsx
+++ b/apps/website/src/components/example/avatar-default.tsx
@@ -1,0 +1,11 @@
+import { Avatar } from "@cocso-ui/react";
+
+export default function AvatarDefault() {
+  return (
+    <div className="flex flex-wrap items-center gap-4 p-4">
+      <Avatar alt="Alice Kim" src="https://i.pravatar.cc/150?img=1" />
+      <Avatar alt="Bob Lee" fallback="BL" />
+      <Avatar alt="Carol Park" />
+    </div>
+  );
+}

--- a/apps/website/src/components/example/avatar-shapes.tsx
+++ b/apps/website/src/components/example/avatar-shapes.tsx
@@ -1,0 +1,16 @@
+import { Avatar } from "@cocso-ui/react";
+
+export default function AvatarShapes() {
+  return (
+    <div className="flex flex-wrap items-center gap-6 p-4">
+      <div className="flex flex-col items-center gap-2">
+        <Avatar alt="Circle" fallback="C" shape="circle" size="lg" />
+        <span className="text-neutral-500 text-sm">circle</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Avatar alt="Square" fallback="S" shape="square" size="lg" />
+        <span className="text-neutral-500 text-sm">square</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/components/example/avatar-sizes.tsx
+++ b/apps/website/src/components/example/avatar-sizes.tsx
@@ -1,0 +1,13 @@
+import { Avatar } from "@cocso-ui/react";
+
+export default function AvatarSizes() {
+  return (
+    <div className="flex flex-wrap items-center gap-4 p-4">
+      <Avatar alt="User" fallback="U" size="xs" />
+      <Avatar alt="User" fallback="U" size="sm" />
+      <Avatar alt="User" fallback="U" size="md" />
+      <Avatar alt="User" fallback="U" size="lg" />
+      <Avatar alt="User" fallback="U" size="xl" />
+    </div>
+  );
+}

--- a/apps/website/src/components/example/breadcrumb-default.tsx
+++ b/apps/website/src/components/example/breadcrumb-default.tsx
@@ -1,0 +1,13 @@
+import { Breadcrumb } from "@cocso-ui/react";
+
+export default function BreadcrumbDefault() {
+  return (
+    <div className="p-4">
+      <Breadcrumb>
+        <a href="/">Home</a>
+        <a href="/products">Products</a>
+        <span>Detail</span>
+      </Breadcrumb>
+    </div>
+  );
+}

--- a/apps/website/src/components/example/breadcrumb-sizes.tsx
+++ b/apps/website/src/components/example/breadcrumb-sizes.tsx
@@ -1,0 +1,23 @@
+import { Breadcrumb } from "@cocso-ui/react";
+
+export default function BreadcrumbSizes() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <Breadcrumb size="sm">
+        <a href="/">Home</a>
+        <a href="/products">Products</a>
+        <span>Detail</span>
+      </Breadcrumb>
+      <Breadcrumb size="md">
+        <a href="/">Home</a>
+        <a href="/products">Products</a>
+        <span>Detail</span>
+      </Breadcrumb>
+      <Breadcrumb size="lg">
+        <a href="/">Home</a>
+        <a href="/products">Products</a>
+        <span>Detail</span>
+      </Breadcrumb>
+    </div>
+  );
+}

--- a/apps/website/src/components/example/card-default.tsx
+++ b/apps/website/src/components/example/card-default.tsx
@@ -1,0 +1,14 @@
+import { Card } from "@cocso-ui/react";
+
+export default function CardDefault() {
+  return (
+    <div className="p-4">
+      <Card style={{ width: 320 }}>
+        <h3 className="font-semibold">Card Title</h3>
+        <p className="mt-1 text-neutral-500 text-sm">
+          This is a card with default elevated style and medium padding.
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/apps/website/src/components/example/card-variants.tsx
+++ b/apps/website/src/components/example/card-variants.tsx
@@ -1,0 +1,20 @@
+import { Card } from "@cocso-ui/react";
+
+export default function CardVariants() {
+  return (
+    <div className="flex flex-wrap gap-4 p-4">
+      <Card style={{ width: 200 }} variant="elevated">
+        <p className="font-medium">Elevated</p>
+        <p className="mt-1 text-neutral-500 text-sm">Raised shadow</p>
+      </Card>
+      <Card style={{ width: 200 }} variant="outlined">
+        <p className="font-medium">Outlined</p>
+        <p className="mt-1 text-neutral-500 text-sm">Border only</p>
+      </Card>
+      <Card style={{ width: 200 }} variant="filled">
+        <p className="font-medium">Filled</p>
+        <p className="mt-1 text-neutral-500 text-sm">Filled background</p>
+      </Card>
+    </div>
+  );
+}

--- a/apps/website/src/components/example/progress-default.tsx
+++ b/apps/website/src/components/example/progress-default.tsx
@@ -1,0 +1,12 @@
+import { Progress } from "@cocso-ui/react";
+
+export default function ProgressDefault() {
+  return (
+    <div className="flex flex-col gap-3 p-4" style={{ width: 360 }}>
+      <Progress value={25} />
+      <Progress value={50} />
+      <Progress value={75} />
+      <Progress value={100} />
+    </div>
+  );
+}

--- a/apps/website/src/components/example/progress-sizes.tsx
+++ b/apps/website/src/components/example/progress-sizes.tsx
@@ -1,0 +1,11 @@
+import { Progress } from "@cocso-ui/react";
+
+export default function ProgressSizes() {
+  return (
+    <div className="flex flex-col gap-4 p-4" style={{ width: 360 }}>
+      <Progress size="sm" value={60} />
+      <Progress size="md" value={60} />
+      <Progress size="lg" value={60} />
+    </div>
+  );
+}

--- a/apps/website/src/components/example/progress-variants.tsx
+++ b/apps/website/src/components/example/progress-variants.tsx
@@ -1,0 +1,14 @@
+import { Progress } from "@cocso-ui/react";
+
+export default function ProgressVariants() {
+  return (
+    <div className="flex flex-col gap-3 p-4" style={{ width: 360 }}>
+      <Progress value={60} variant="primary" />
+      <Progress value={60} variant="secondary" />
+      <Progress value={60} variant="success" />
+      <Progress value={60} variant="danger" />
+      <Progress value={60} variant="warning" />
+      <Progress value={60} variant="info" />
+    </div>
+  );
+}

--- a/apps/website/src/components/example/skeleton-animations.tsx
+++ b/apps/website/src/components/example/skeleton-animations.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@cocso-ui/react";
+
+export default function SkeletonAnimations() {
+  return (
+    <div className="flex flex-col gap-4 p-4" style={{ width: 320 }}>
+      <div className="flex flex-col gap-1">
+        <Skeleton animation="pulse" variant="text" />
+        <span className="text-neutral-500 text-sm">pulse</span>
+      </div>
+      <div className="flex flex-col gap-1">
+        <Skeleton animation="wave" variant="text" />
+        <span className="text-neutral-500 text-sm">wave</span>
+      </div>
+      <div className="flex flex-col gap-1">
+        <Skeleton animation="none" variant="text" />
+        <span className="text-neutral-500 text-sm">none</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/components/example/skeleton-default.tsx
+++ b/apps/website/src/components/example/skeleton-default.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@cocso-ui/react";
+
+export default function SkeletonDefault() {
+  return (
+    <div className="p-4" style={{ width: 320 }}>
+      <div className="flex gap-3">
+        <Skeleton style={{ width: 40, height: 40 }} variant="circular" />
+        <div className="flex flex-1 flex-col gap-2">
+          <Skeleton variant="text" />
+          <Skeleton style={{ width: "60%" }} variant="text" />
+        </div>
+      </div>
+      <div className="mt-3 flex flex-col gap-2">
+        <Skeleton variant="text" />
+        <Skeleton variant="text" />
+        <Skeleton style={{ width: "80%" }} variant="text" />
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/components/example/skeleton-variants.tsx
+++ b/apps/website/src/components/example/skeleton-variants.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@cocso-ui/react";
+
+export default function SkeletonVariants() {
+  return (
+    <div className="flex flex-wrap items-center gap-6 p-4">
+      <div className="flex flex-col items-center gap-2">
+        <Skeleton style={{ width: 200 }} variant="text" />
+        <span className="text-neutral-500 text-sm">text</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Skeleton style={{ width: 48, height: 48 }} variant="circular" />
+        <span className="text-neutral-500 text-sm">circular</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Skeleton style={{ width: 200, height: 120 }} variant="rectangular" />
+        <span className="text-neutral-500 text-sm">rectangular</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/components/ui/search.tsx
+++ b/apps/website/src/components/ui/search.tsx
@@ -35,7 +35,7 @@ export const DefaultSearchDialog = (props: SharedProps) => {
           <SearchDialogInput />
           <SearchDialogClose />
         </SearchDialogHeader>
-        <SearchDialogList items={query.data !== "empty" ? query.data : null} />
+        <SearchDialogList items={query.data === "empty" ? null : query.data} />
       </SearchDialogContent>
     </SearchDialog>
   );

--- a/apps/website/src/components/ui/token-table.tsx
+++ b/apps/website/src/components/ui/token-table.tsx
@@ -15,7 +15,7 @@ interface TokenTableProps extends ComponentProps<"div"> {
 export const TokenTable = ({ data, className, ...props }: TokenTableProps) => {
   return (
     <div className={twMerge("w-full overflow-x-auto", className)} {...props}>
-      <table className="w-full border-collapse text-sm">
+      <table className="w-full border-collapse text-[11px]">
         <thead>
           <tr className="border-neutral-200 border-b text-left">
             <th className="whitespace-nowrap px-3 py-2 font-semibold text-neutral-950">
@@ -39,17 +39,17 @@ export const TokenTable = ({ data, className, ...props }: TokenTableProps) => {
               key={token.name}
             >
               <td className="px-3 py-2.5 align-middle">
-                <code className="rounded bg-neutral-50 px-1.5 py-0.5 font-mono text-[13px] text-neutral-900">
+                <code className="rounded bg-neutral-50 px-1.5 py-0.5 font-mono text-[11px] text-neutral-900">
                   {token.name}
                 </code>
               </td>
               <td className="px-3 py-2.5 align-middle">
-                <code className="font-mono text-[13px] text-info-600">
+                <code className="font-mono text-[11px] text-info-600">
                   {token.token}
                 </code>
               </td>
               <td className="px-3 py-2.5 align-middle">
-                <code className="font-mono text-[13px] text-neutral-600">
+                <code className="font-mono text-[11px] text-neutral-600">
                   {token.value}
                 </code>
               </td>

--- a/apps/website/src/constants/sidebar.ts
+++ b/apps/website/src/constants/sidebar.ts
@@ -13,8 +13,12 @@ type Sidebar = Record<string, SidebarSection>;
 
 const componentItems: readonly SidebarItem[] = [
   { type: "page", name: "Accordion", url: "/components/accordion" },
+  { type: "page", name: "Alert", url: "/components/alert" },
+  { type: "page", name: "Avatar", url: "/components/avatar" },
   { type: "page", name: "Badge", url: "/components/badge" },
+  { type: "page", name: "Breadcrumb", url: "/components/breadcrumb" },
   { type: "page", name: "Button", url: "/components/button" },
+  { type: "page", name: "Card", url: "/components/card" },
   { type: "page", name: "Checkbox", url: "/components/checkbox" },
   { type: "page", name: "Day Picker", url: "/components/day-picker" },
   { type: "page", name: "Dialog", url: "/components/dialog" },
@@ -30,8 +34,10 @@ const componentItems: readonly SidebarItem[] = [
   },
   { type: "page", name: "Pagination", url: "/components/pagination" },
   { type: "page", name: "Popover", url: "/components/popover" },
+  { type: "page", name: "Progress", url: "/components/progress" },
   { type: "page", name: "Radio Group", url: "/components/radio-group" },
   { type: "page", name: "Select", url: "/components/select" },
+  { type: "page", name: "Skeleton", url: "/components/skeleton" },
   { type: "page", name: "Spinner", url: "/components/spinner" },
   {
     type: "page",

--- a/packages/react/rollup.config.cjs
+++ b/packages/react/rollup.config.cjs
@@ -47,7 +47,7 @@ function buildJS(format, input, output) {
     ],
     plugins: [
       postcss({
-        modules: true,
+        autoModules: true,
         minimize: true,
         extract: isESM,
       }),


### PR DESCRIPTION
## Summary

- Alert, Avatar, Breadcrumb, Card, Progress, Skeleton 6개 컴포넌트 문서 페이지 추가
- 영어/한국어 MDX 페이지 (overview, accessibility, import, usage examples, API reference)
- 15개 인터랙티브 예제 컴포넌트 추가 (variants, sizes, shapes, animations)
- 사이드바 네비게이션에 6개 컴포넌트 등록

## Test plan

- [ ] 웹사이트에서 각 컴포넌트 문서 페이지 정상 렌더링 확인
- [ ] 영어/한국어 페이지 모두 확인
- [ ] 사이드바 네비게이션 링크 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)