### PR TITLE
react: layer floating popups above dialogs

### DIFF
--- a/.changeset/cold-zindex-layering.md
+++ b/.changeset/cold-zindex-layering.md
@@ -1,0 +1,12 @@
+---
+"@cocso-ui/baseframe-sources": minor
+"@cocso-ui/css": minor
+"@cocso-ui/react": patch
+---
+
+Add a dedicated floating layer to the z-index scale so popups always render above modals.
+
+- Add `popover` (300) and `tooltip` (400) z-index tokens, above `dialog` (200).
+- Dropdown and Popover positioners now use `--cocso-z-index-popover`; Tooltip uses `--cocso-z-index-tooltip`. DayPicker/MonthPicker inherit the dropdown layer.
+- Fixes tooltips and dropdowns (incl. DayPicker/MonthPicker) being hidden behind dialog content when opened inside a Dialog.
+- Remove the redundant `z-index` on the Dropdown popup; the layer belongs on the Positioner per the floating component contract.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,18 @@ When asked to review comments on a GitHub PR:
   `z-index` on the `Positioner`, not the inner popup — the Positioner owns the
   stacking context via its `transform`, so a `z-index` on the popup alone is
   ignored by ancestors.
+- The z-index scale ascends so floating layers always sit above modals
+  (portals flatten to `<body>`, so stacking is decided by `z-index` alone):
+  `header (50)` < `overlay (100, dialog backdrop)` < `dialog (200, dialog
+  content)` < `popover (300, dropdown/popover and anything built on Dropdown
+  such as DayPicker/MonthPicker)` < `tooltip (400)`. This guarantees a tooltip
+  or dropdown opened inside a Dialog renders above the dialog content. Toast is
+  rendered by `sonner` and intentionally sits above this scale; do not assign it
+  a token.
+- Trigger-attached floating surfaces MUST use `--cocso-z-index-popover`;
+  tooltips MUST use `--cocso-z-index-tooltip`. Do NOT use
+  `--cocso-z-index-overlay` for floating popups — it is the dialog backdrop
+  layer and would render the popup behind dialog content.
 
 ### Frontend Design Rules
 

--- a/docs/project-baseframe-sources.md
+++ b/docs/project-baseframe-sources.md
@@ -41,7 +41,7 @@ packages/baseframe-sources/
 │   ├── font-weight.yaml    # $font-weight.thin through $font-weight.black
 │   ├── shadow.yaml         # $shadow.1 through $shadow.4, shadow dimensions
 │   ├── spacing.yaml        # $spacing.0 through $spacing.max
-│   └── z-index.yaml        # $z-index.behind through $z-index.dialog-content
+│   └── z-index.yaml        # $z-index.behind through $z-index.tooltip
 └── semantic/               # Alias tokens
     └── color.yaml          # $color.alpha.*, $color.text.*
 ```

--- a/ecosystem/baseframe/src/__tests__/snapshots/tailwind4.css.expected
+++ b/ecosystem/baseframe/src/__tests__/snapshots/tailwind4.css.expected
@@ -121,6 +121,8 @@
   --z-index-overlay: var(--cocso-z-index-overlay);
   --z-index-dialog: var(--cocso-z-index-dialog);
   --z-index-dialog-content: var(--cocso-z-index-dialog-content);
+  --z-index-popover: var(--cocso-z-index-popover);
+  --z-index-tooltip: var(--cocso-z-index-tooltip);
   --color-alpha-shadow1: var(--cocso-color-alpha-shadow1);
   --color-alpha-shadow2: var(--cocso-color-alpha-shadow2);
   --color-alpha-shadow3: var(--cocso-color-alpha-shadow3);

--- a/ecosystem/baseframe/src/__tests__/snapshots/token.css.expected
+++ b/ecosystem/baseframe/src/__tests__/snapshots/token.css.expected
@@ -144,6 +144,8 @@
   --cocso-z-index-overlay: 100;
   --cocso-z-index-dialog: 200;
   --cocso-z-index-dialog-content: 250;
+  --cocso-z-index-popover: 300;
+  --cocso-z-index-tooltip: 400;
   --cocso-color-alpha-shadow1: rgba(0, 0, 0, 0.04);
   --cocso-color-alpha-shadow2: rgba(0, 0, 0, 0.08);
   --cocso-color-alpha-shadow3: rgba(0, 0, 0, 0.12);

--- a/packages/baseframe-sources/primitive/z-index.yaml
+++ b/packages/baseframe-sources/primitive/z-index.yaml
@@ -27,5 +27,11 @@ data:
     $z-index.dialog-content:
       values:
         default: "250"
+    $z-index.popover:
+      values:
+        default: "300"
+    $z-index.tooltip:
+      values:
+        default: "400"
 
 

--- a/packages/css/tailwind4.css
+++ b/packages/css/tailwind4.css
@@ -121,6 +121,8 @@
   --z-index-overlay: var(--cocso-z-index-overlay);
   --z-index-dialog: var(--cocso-z-index-dialog);
   --z-index-dialog-content: var(--cocso-z-index-dialog-content);
+  --z-index-popover: var(--cocso-z-index-popover);
+  --z-index-tooltip: var(--cocso-z-index-tooltip);
   --color-alpha-shadow1: var(--cocso-color-alpha-shadow1);
   --color-alpha-shadow2: var(--cocso-color-alpha-shadow2);
   --color-alpha-shadow3: var(--cocso-color-alpha-shadow3);

--- a/packages/css/token.css
+++ b/packages/css/token.css
@@ -144,6 +144,8 @@
   --cocso-z-index-overlay: 100;
   --cocso-z-index-dialog: 200;
   --cocso-z-index-dialog-content: 250;
+  --cocso-z-index-popover: 300;
+  --cocso-z-index-tooltip: 400;
   --cocso-color-alpha-shadow1: rgba(0, 0, 0, 0.04);
   --cocso-color-alpha-shadow2: rgba(0, 0, 0, 0.08);
   --cocso-color-alpha-shadow3: rgba(0, 0, 0, 0.12);

--- a/packages/react/src/components/dropdown/dropdown.module.css
+++ b/packages/react/src/components/dropdown/dropdown.module.css
@@ -32,11 +32,10 @@
   }
 
   .positioner {
-    z-index: var(--cocso-z-index-overlay);
+    z-index: var(--cocso-z-index-popover);
   }
 
   .content {
-    z-index: var(--cocso-z-index-overlay);
     display: flex;
     flex-direction: column;
     min-width: 128px;

--- a/packages/react/src/components/popover/popover.module.css
+++ b/packages/react/src/components/popover/popover.module.css
@@ -50,7 +50,7 @@
   }
 
   .positioner {
-    z-index: var(--cocso-z-index-overlay);
+    z-index: var(--cocso-z-index-popover);
   }
 
   .content {

--- a/packages/react/src/components/tooltip/tooltip.module.css
+++ b/packages/react/src/components/tooltip/tooltip.module.css
@@ -50,7 +50,7 @@
   }
 
   .positioner {
-    z-index: var(--cocso-z-index-overlay);
+    z-index: var(--cocso-z-index-tooltip);
   }
 
   .content {


### PR DESCRIPTION
## Summary

Floating popups (Tooltip, Dropdown, Popover, DayPicker, MonthPicker) all shared the `overlay` (100) z-index layer — the same layer as the Dialog backdrop. Dialog content sits at `dialog` (200), so any popup opened **inside** a Dialog rendered *behind* the dialog content.

This introduces a dedicated floating tier in the z-index scale so popups always stack above modals.

## Changes

- Add `popover` (300) and `tooltip` (400) z-index tokens (source: `z-index.yaml` → `token.css` → `tailwind4.css`).
- Dropdown/Popover positioners → `--cocso-z-index-popover`; Tooltip → `--cocso-z-index-tooltip`. DayPicker/MonthPicker inherit via Dropdown.
- Remove the redundant `z-index` on the Dropdown popup (belongs on the Positioner per the floating component contract).
- Document the layering scale in `AGENTS.md`.

## Scale (ascending)

`header 50 < overlay 100 (dialog backdrop) < dialog 200 (dialog content) < dialog-content 250 < popover 300 < tooltip 400`

Toast (`sonner`) intentionally sits above this scale and is not tokenized.

## Notes

- `select` is a native `<select>` (no portal) — unchanged.
- Unused primitive tokens (`behind`/`base`/`above`/`header`/`dialog-content`) are public and retained.
- Changeset: `@cocso-ui/css` minor, `@cocso-ui/baseframe-sources` minor, `@cocso-ui/react` patch.
- `pnpm check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)