### PR TITLE
changeset: only major-bump peer dependents when out of range

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@cocso-ui/storybook", "@cocso-ui/website"]
+  "ignore": ["@cocso-ui/storybook", "@cocso-ui/website"],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }


### PR DESCRIPTION
## Summary

`@cocso-ui/react` peer-depends on `@cocso-ui/css` (`workspace:^`). With Changesets' default behavior, **any** bump to `@cocso-ui/css` force-majors `@cocso-ui/react` — even when the new css version stays inside react's caret range.

This caused the pending version PR to bump `@cocso-ui/react` to **2.0.0** for a css **minor** (additive z-index tokens), which is wrong: consumers on `react@1` + `css@^1` need no change.

## Fix

Enable `onlyUpdatePeerDependentsWhenOutOfRange`. css `1.1.0` stays within react's `^1.0.0` peer range, so react now bumps only for its own changeset (patch → `1.0.2`).

Verified locally with `changeset version`:

- `@cocso-ui/css` → `1.1.0`
- `@cocso-ui/react` → `1.0.2` (was `2.0.0`)
- `@cocso-ui/baseframe-sources` → `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)